### PR TITLE
[WIP] Password credentials store tests

### DIFF
--- a/src/main/java/com/reckue/oauth/service/PasswordCredentialsValidatorService.java
+++ b/src/main/java/com/reckue/oauth/service/PasswordCredentialsValidatorService.java
@@ -5,12 +5,17 @@ import com.reckue.oauth.model.PasswordCredentials;
 import com.reckue.oauth.repository.PasswordCredentialsRepository;
 import com.reckue.oauth.service.interfaces.StoreValidatorService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor
 public class PasswordCredentialsValidatorService implements StoreValidatorService<PasswordCredentials> {
+
+    Logger logger = LoggerFactory.getLogger(PasswordCredentialsValidatorService.class);
 
     private final PasswordCredentialsRepository passwordCredentialsRepository;
 
@@ -18,10 +23,12 @@ public class PasswordCredentialsValidatorService implements StoreValidatorServic
 
     @Override
     public boolean exists(PasswordCredentials entity) {
-        Example<PasswordCredentials> exampleEmail = mongoExampleFactory.produce(entity, "username");
-        Example<PasswordCredentials> exampleUsername = mongoExampleFactory.produce(entity, "email");
+        Example<PasswordCredentials> exampleEmail = mongoExampleFactory.produce(entity, "id", "username");
+        Example<PasswordCredentials> exampleUsername = mongoExampleFactory.produce(entity, "id", "email");
         boolean existsEmail = passwordCredentialsRepository.exists(exampleEmail);
+        logger.info("Exists email:password pair = " + existsEmail);
         boolean existsUsername = passwordCredentialsRepository.exists(exampleUsername);
+        logger.info("Exists username:password pair = " + existsUsername);
         return existsEmail || existsUsername;
     }
 

--- a/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
+++ b/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
@@ -6,11 +6,19 @@ import com.reckue.oauth.factory.base.MongoExampleFactory;
 import com.reckue.oauth.mock.MockPasswordCredentialsRepository;
 import com.reckue.oauth.mock.MockPasswordCredentialsValidatorService;
 import com.reckue.oauth.mock.MockUuidFactory;
+import com.reckue.oauth.model.PasswordCredentials;
+import com.reckue.oauth.service.PasswordCredentialsStoreService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static com.reckue.oauth.utils.AlreadyExistsUtil.checkThrowReckuePasswordCredentialsAlreadyExists;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = {
         MockPasswordCredentialsRepository.class,
         MockPasswordCredentialsValidatorService.class,
+        PasswordCredentialsStoreService.class,
         MongoExampleFactory.class,
         ExampleMatcherFactory.class,
         MockUuidFactory.class,
@@ -18,4 +26,32 @@ import org.springframework.boot.test.context.SpringBootTest;
 })
 public class PasswordCredentialsStoreServiceTest {
 
+    @Autowired
+    private PasswordCredentialsStoreService passwordCredentialsStoreService;
+
+    @Autowired
+    private PasswordCredentialsFactory passwordCredentialsFactory;
+
+    @Test
+    public void create() {
+        checkThrowReckuePasswordCredentialsAlreadyExists(() ->
+                passwordCredentialsStoreService.create(passwordCredentialsFactory.produce())
+        );
+    }
+
+    @Test
+    public void findById() {
+        PasswordCredentials expected = passwordCredentialsFactory.produce();
+        String id = expected.getId();
+        PasswordCredentials actual = passwordCredentialsStoreService.findById(id);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void delete() {
+        PasswordCredentials expected = passwordCredentialsFactory.produce();
+        String id = expected.getId();
+        PasswordCredentials actual = passwordCredentialsStoreService.delete(id);
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
+++ b/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
@@ -1,8 +1,21 @@
 package com.reckue.oauth.cases.service;
 
+import com.reckue.oauth.factory.PasswordCredentialsFactory;
+import com.reckue.oauth.factory.base.ExampleMatcherFactory;
+import com.reckue.oauth.factory.base.MongoExampleFactory;
+import com.reckue.oauth.mock.MockPasswordCredentialsRepository;
+import com.reckue.oauth.mock.MockPasswordCredentialsValidatorService;
+import com.reckue.oauth.mock.MockUuidFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = {
+        MockPasswordCredentialsRepository.class,
+        MockPasswordCredentialsValidatorService.class,
+        MongoExampleFactory.class,
+        ExampleMatcherFactory.class,
+        MockUuidFactory.class,
+        PasswordCredentialsFactory.class
+})
 public class PasswordCredentialsStoreServiceTest {
 
 }

--- a/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
+++ b/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsStoreServiceTest.java
@@ -1,0 +1,8 @@
+package com.reckue.oauth.cases.service;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PasswordCredentialsStoreServiceTest {
+
+}

--- a/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsValidatorServiceTest.java
+++ b/src/test/java/com/reckue/oauth/cases/service/PasswordCredentialsValidatorServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static com.reckue.oauth.utils.AlreadyExistsUtil.checkThrowReckuePasswordCredentialsAlreadyExists;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(classes = {
@@ -39,10 +40,9 @@ public class PasswordCredentialsValidatorServiceTest {
     @Test
     public void passwordCredentialsAlreadyExists() {
         PasswordCredentials passwordCredentials = passwordCredentialsFactory.produce();
-        Exception exception = assertThrows(RuntimeException.class, () ->
+        checkThrowReckuePasswordCredentialsAlreadyExists(() ->
                 passwordCredentialsValidatorService.checkAlreadyExists(passwordCredentials)
         );
-        assertEquals("Password credentials already exists.", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/reckue/oauth/cases/store/PasswordCredentialsStoreTest.java
+++ b/src/test/java/com/reckue/oauth/cases/store/PasswordCredentialsStoreTest.java
@@ -1,0 +1,44 @@
+package com.reckue.oauth.cases.store;
+
+import com.reckue.oauth.factory.PasswordCredentialsFactory;
+import com.reckue.oauth.factory.base.MongoExampleFactory;
+import com.reckue.oauth.model.PasswordCredentials;
+import com.reckue.oauth.repository.PasswordCredentialsRepository;
+import com.reckue.oauth.service.PasswordCredentialsStoreService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+public class PasswordCredentialsStoreTest {
+
+    @Autowired
+    private PasswordCredentialsStoreService passwordCredentialsStoreService;
+
+    @Autowired
+    private PasswordCredentialsRepository passwordCredentialsRepository;
+
+    @Autowired
+    private MongoExampleFactory<PasswordCredentials> mongoExampleFactory;
+
+    @Autowired
+    private PasswordCredentialsFactory passwordCredentialsFactory;
+
+    @Test
+    public void createPasswordCredentials() {
+        PasswordCredentials passwordCredentials = passwordCredentialsFactory.produce();
+        long count = passwordCredentialsRepository.count(mongoExampleFactory.produce(passwordCredentials));
+        if (count > 0) {
+            Exception exception = assertThrows(RuntimeException.class, () ->
+                    passwordCredentialsStoreService.create(passwordCredentials)
+            );
+            assertEquals("Password credentials already exists.", exception.getMessage());
+        } else {
+            PasswordCredentials saved = passwordCredentialsStoreService.create(passwordCredentials);
+            assertEquals(passwordCredentials, saved);
+        }
+    }
+}

--- a/src/test/java/com/reckue/oauth/cases/store/PasswordCredentialsStoreTest.java
+++ b/src/test/java/com/reckue/oauth/cases/store/PasswordCredentialsStoreTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import static com.reckue.oauth.utils.AlreadyExistsUtil.checkThrowReckuePasswordCredentialsAlreadyExists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 public class PasswordCredentialsStoreTest {
@@ -32,10 +32,9 @@ public class PasswordCredentialsStoreTest {
         PasswordCredentials passwordCredentials = passwordCredentialsFactory.produce();
         long count = passwordCredentialsRepository.count(mongoExampleFactory.produce(passwordCredentials));
         if (count > 0) {
-            Exception exception = assertThrows(RuntimeException.class, () ->
+            checkThrowReckuePasswordCredentialsAlreadyExists(() ->
                     passwordCredentialsStoreService.create(passwordCredentials)
             );
-            assertEquals("Password credentials already exists.", exception.getMessage());
         } else {
             PasswordCredentials saved = passwordCredentialsStoreService.create(passwordCredentials);
             assertEquals(passwordCredentials, saved);

--- a/src/test/java/com/reckue/oauth/factory/PasswordCredentialsFactory.java
+++ b/src/test/java/com/reckue/oauth/factory/PasswordCredentialsFactory.java
@@ -3,9 +3,9 @@ package com.reckue.oauth.factory;
 import com.reckue.oauth.factory.base.UuidFactory;
 import com.reckue.oauth.model.PasswordCredentials;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.test.context.TestComponent;
+import org.springframework.stereotype.Component;
 
-@TestComponent
+@Component
 @RequiredArgsConstructor
 public class PasswordCredentialsFactory implements IndependentFactory<PasswordCredentials> {
 

--- a/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsRepository.java
+++ b/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsRepository.java
@@ -9,8 +9,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Example;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @TestConfiguration
 @RequiredArgsConstructor
@@ -24,7 +23,19 @@ public class MockPasswordCredentialsRepository {
     public PasswordCredentialsRepository getPasswordCredentialsRepository() {
         PasswordCredentialsRepository repository = mock(PasswordCredentialsRepository.class);
         mockExistsMethod(repository, passwordCredentialsFactory.produce());
+        mockFindByIdMethod(repository, passwordCredentialsFactory.produce());
+        mockDeleteByIdMethod(repository, passwordCredentialsFactory.produce());
         return repository;
+    }
+
+    private void mockFindByIdMethod(PasswordCredentialsRepository repository, PasswordCredentials entity) {
+        String id = entity.getId();
+        when(repository.findById(id)).thenReturn(java.util.Optional.of(entity));
+    }
+
+    private void mockDeleteByIdMethod(PasswordCredentialsRepository repository, PasswordCredentials entity) {
+        String id = entity.getId();
+        doNothing().when(repository).deleteById(id);
     }
 
     private void mockExistsMethod(PasswordCredentialsRepository repository, PasswordCredentials entity) {

--- a/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsRepository.java
+++ b/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsRepository.java
@@ -28,8 +28,8 @@ public class MockPasswordCredentialsRepository {
     }
 
     private void mockExistsMethod(PasswordCredentialsRepository repository, PasswordCredentials entity) {
-        Example<PasswordCredentials> exampleEmail = mongoExampleFactory.produce(entity, "username");
-        Example<PasswordCredentials> exampleUsername = mongoExampleFactory.produce(entity, "email");
+        Example<PasswordCredentials> exampleEmail = mongoExampleFactory.produce(entity, "id", "username");
+        Example<PasswordCredentials> exampleUsername = mongoExampleFactory.produce(entity, "id", "email");
         when(repository.exists(exampleEmail)).thenReturn(true);
         when(repository.exists(exampleUsername)).thenReturn(true);
     }

--- a/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsValidatorService.java
+++ b/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsValidatorService.java
@@ -1,0 +1,27 @@
+package com.reckue.oauth.mock;
+
+import com.reckue.oauth.factory.PasswordCredentialsFactory;
+import com.reckue.oauth.service.PasswordCredentialsValidatorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.mockito.Mockito.*;
+
+@TestConfiguration
+@RequiredArgsConstructor
+public class MockPasswordCredentialsValidatorService {
+
+    private final PasswordCredentialsFactory passwordCredentialsFactory;
+
+    @Bean
+    public PasswordCredentialsValidatorService getPasswordCredentialsValidatorService() {
+        PasswordCredentialsValidatorService service = mock(PasswordCredentialsValidatorService.class);
+        when(service.exists(passwordCredentialsFactory.produce()))
+                .thenReturn(true);
+        doThrow(new RuntimeException("Password credentials already exists."))
+                .when(service)
+                .checkAlreadyExists(passwordCredentialsFactory.produce());
+        return service;
+    }
+}

--- a/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsValidatorService.java
+++ b/src/test/java/com/reckue/oauth/mock/MockPasswordCredentialsValidatorService.java
@@ -1,8 +1,10 @@
 package com.reckue.oauth.mock;
 
 import com.reckue.oauth.factory.PasswordCredentialsFactory;
+import com.reckue.oauth.model.PasswordCredentials;
 import com.reckue.oauth.service.PasswordCredentialsValidatorService;
 import lombok.RequiredArgsConstructor;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -17,11 +19,11 @@ public class MockPasswordCredentialsValidatorService {
     @Bean
     public PasswordCredentialsValidatorService getPasswordCredentialsValidatorService() {
         PasswordCredentialsValidatorService service = mock(PasswordCredentialsValidatorService.class);
-        when(service.exists(passwordCredentialsFactory.produce()))
-                .thenReturn(true);
-        doThrow(new RuntimeException("Password credentials already exists."))
+        PasswordCredentials passwordCredentials = passwordCredentialsFactory.produce();
+        when(service.exists(passwordCredentials)).thenReturn(true);
+        Mockito.doThrow(new RuntimeException("Password credentials already exists."))
                 .when(service)
-                .checkAlreadyExists(passwordCredentialsFactory.produce());
+                .checkAlreadyExists(passwordCredentials);
         return service;
     }
 }

--- a/src/test/java/com/reckue/oauth/utils/AlreadyExistsUtil.java
+++ b/src/test/java/com/reckue/oauth/utils/AlreadyExistsUtil.java
@@ -1,0 +1,22 @@
+package com.reckue.oauth.utils;
+
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AlreadyExistsUtil {
+
+    public static void checkThrowReckuePasswordCredentialsAlreadyExists(Executable executable) {
+        checkThrowReckueExceptionWithMessage("Password credentials already exists.", executable);
+    }
+
+    public static void checkThrowReckueExceptionWithMessage(String expectedMessage, Executable executable) {
+        Exception exception = assertThrows(RuntimeException.class, executable);
+        checkMessage(expectedMessage, exception);
+    }
+
+    private static void checkMessage(String expected, Exception actual) {
+        assertEquals(expected, actual.getMessage());
+    }
+}


### PR DESCRIPTION
PasswordCredentialsStoreService service unit tests and PasswordCredentialsStore tests without mocks. 
Fixed bug with mongo entity examples. Id was not included into examples ignore cases. 
Every entity with generated id was unique. That was wrong. Now it fixed.

[WIP] Wait for PasswordCredentialsStoreService test cases.